### PR TITLE
[Workaround] Fix the Python 3.5, 3.6 CI build failed

### DIFF
--- a/.github/workflows/cr-pytest.yml
+++ b/.github/workflows/cr-pytest.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
         python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
 
     runs-on : ${{ matrix.os }}


### PR DESCRIPTION
[Issue Statement]
GitHub action use the latest 22.04-Ubuntu.
It is not supported to execute the Python
3.5/3.6 environment.

[Resolution]
Assign the 20.04-Ubuntu as workaround.

Signed-off-by: Jason Lin <jason40418@gmail.com>