### PR TITLE
[CI] Migrate the Python Version to Align the SWLC

### DIFF
--- a/.github/workflows/cr-pytest.yml
+++ b/.github/workflows/cr-pytest.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     runs-on : ${{ matrix.os }}
 


### PR DESCRIPTION
[Feature Statement]
- Python SWLC for Python 3.5 - Python 3.7 had been EOL.

[Changes]
- Change the ubuntu OS into latest one
- Deprecate the Python 3.5 - Python 3.7
- Add the Python 3.11 - Python 3.12

[Reference]
- https://devguide.python.org/versions/