### PR TITLE
[CI] Set the Configuration to Enable the CodeQL

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,4 +1,64 @@
-name: "Security and Quality"
+name: "CodeQL: Security and Quality"
 
-queries:
-  - uses: security-and-quality
+on:
+  push:
+    branches: [
+      'main'
+      ]
+  pull_request:
+    branches: [
+      'main',
+      'dev/**'
+      ]
+  schedule:
+    - cron: '00 03 * * *'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: ['python']
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries:
+            - default
+            - security-extended
+
+      - if: matrix.build-mode == 'manual'
+        run: |
+          echo 'If you are using a "manual" build mode for one or more of the' \
+            'languages you are analyzing, replace this with the commands to build' \
+            'your code, for example:'
+          echo '  make bootstrap'
+          echo '  make release'
+          exit 1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"


### PR DESCRIPTION
[Feature Description]
- CodeQL is disabled due to the incorrect configuration.
- Correct the configuration file to enable this functionality.

[Changes]
- Execute the CodeQL when below action happening - pull on "main" branch - pull_request on "main" and "dev/**" branch - schedule on each day 03:00 to scan

- Set the scan language as Python only - Include "default" and "security-extended" queries